### PR TITLE
Email Verification

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -21,3 +21,4 @@ blaze-html-templates
 meteortoys:allthings
 meteortesting:mocha
 accounts-password
+email

--- a/client/main.css
+++ b/client/main.css
@@ -1,0 +1,4 @@
+body {
+    padding: 10px;
+    font-family: sans-serif;
+}

--- a/client/main.html
+++ b/client/main.html
@@ -1,0 +1,7 @@
+<head>
+    <title>Grocee</title>
+</head>
+
+<body>
+<div id="render-target"></div>
+</body>

--- a/client/main.js
+++ b/client/main.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Meteor } from 'meteor/meteor';
+import { render } from 'react-dom';
+
+import VerifyEmail from '../imports/ui/VerifyEmail';
+import {Accounts} from "meteor/accounts-base";
+
+Meteor.startup(() => {
+	//TODO: create proper main view?
+	render(<VerifyEmail />, document.getElementById('render-target'));
+});
+
+Accounts.onEmailVerificationLink(function (token) {
+	Accounts.verifyEmail(token);
+	//TODO: create proper verify password page
+});
+
+Accounts.onResetPasswordLink(function (token) {
+	console.log('Resetting password...');
+	console.log('token: ' + token);
+	//TODO: render reset password page, let user enter new password, then call Accounts.resetPassword
+	// https://docs.meteor.com/api/passwords.html#Accounts-resetPassword
+});

--- a/client/main.js
+++ b/client/main.js
@@ -16,8 +16,8 @@ Accounts.onEmailVerificationLink(function (token) {
 });
 
 Accounts.onResetPasswordLink(function (token) {
-	console.log('Resetting password...');
-	console.log('token: ' + token);
+	console.log('Resetting password...'); // eslint-disable-line
+	console.log('token: ' + token); // eslint-disable-line
 	//TODO: render reset password page, let user enter new password, then call Accounts.resetPassword
 	// https://docs.meteor.com/api/passwords.html#Accounts-resetPassword
 });

--- a/imports/api/accounts.js
+++ b/imports/api/accounts.js
@@ -1,5 +1,6 @@
 import { Meteor } from 'meteor/meteor';
 import { check } from 'meteor/check';
+import { Accounts } from 'meteor/accounts-base';
 
 Meteor.publish('Meteor.users.names', function () {
 	if (this.userId) {
@@ -22,5 +23,11 @@ Meteor.methods({
 				lastName: newLastName
 			}
 		});
+	},
+	'accounts.resendVerificationEmail'() {
+		Accounts.sendVerificationEmail(this.userId);
+	},
+	'accounts.sendPasswordResetEmail'() {
+		Accounts.sendResetPasswordEmail(this.userId);
 	},
 });

--- a/imports/ui/VerifyEmail.js
+++ b/imports/ui/VerifyEmail.js
@@ -1,0 +1,15 @@
+import React, { Component } from 'react';
+
+export default class VerifyEmail extends Component {
+
+	// TODO: just a placeholder view for email verification
+	render() {
+		return (
+			<div className="container">
+				<header>
+					<p>Verifying email...</p>
+				</header>
+			</div>
+		)
+	}
+}


### PR DESCRIPTION
- Added two new methods for sending out emails for verification and password reset
- Added a dummy main page to do the actual email verification on the client-side

Still need to set up proper routes for email verification and password resets for the client

For the Heroku side, I've set up the SMTP server using SendGrid and successfully connected it for Meteor to use to send our these emails by setting up the environment variable `MAIL_URL`. **Still need to verify that it works in the Heroku environment** once this is merged into development and deployed there.